### PR TITLE
Break apart Validity into Validity + Handle w/ BitFlags

### DIFF
--- a/docs/planning.md
+++ b/docs/planning.md
@@ -119,3 +119,79 @@ Optionally, the validity checks can be executed before and after each of the abo
 - [ ] Reporting
   - [ ] HTML
   - [ ] DataFrame
+
+# Checks & Validity Objects
+
+## ValidityResult Object
+
+## FeedReport
+
+## SymbolReport
+
+## Report
+
+## ValidityInstruction
+
+ValidityInstruction objects contain information used to check a Symbol's data.  The end application
+should never "see" the data from the individual feeds, however a validity check can peek at it for the purposes of checking the final.
+
+A symbol has a single .isvalid() method, which will run the checks associated with each ValidityInstruction Object.
+The function returns a ValidityResult object.  The ValidtyResult object can be compared against a boolean, in an all-or-nothing way,
+or it can be converted to a list of booleans, a dictionary of booleans where the keys are the names of the individual checks,
+or a more advanced object which is a dictionary keyed by the test name, but the value returned is an object decided by the test.
+
+Examples of Validity Checks might be:
+
+- Length
+- MissingData (gaps)
+- Recency [has there been data in the last X days]
+- Today [is there a datapoint for today]
+- Last-Close-to-Others
+- FrequencyAutoDetect
+- StandardDeviationLevel (eg. Realized Volatility)
+- DeviationFromMovingAverage
+- FeedLengthCompare
+- FeedDeviationCompare
+- CheckExistence
+
+## FeedHandle & SymbolHandle
+
+A *Handle object is attached to each Symbol, and Feed, one-to-one.  So, a Symbol with 3 Feeds, would have 1 SymbolHandle, and 3 FeedHandle objects.
+
+It contains instructions about how to handle common exceptions raised during the caching of an individual Feeds, or the aggregation of a Symbol.
+
+Trump has default settings for each type of failure, that get read from the config file when a SymbolManager is instantiated.
+The defaults stored in the config, get attached permanently to the Feed or Symbol upon instatiation.  One can update them,
+at any point.
+
+The catch points for a Feed include:
+
+- APIfailure [of any-kind] 
+- Empty Feed [length of 0]
+- Index Type Problem [Eg. expecting Periods, got DateTimes]
+- Index Property Problem [Eg. expecting 'B', got 'D']
+- Data Type Failure [Eg. expecting floats, got strings]
+- Non-monotonic [Eg. expecting monotonic, got non-monotonic]
+- Other [Eg. Any other kind of problem]
+
+The catch points for a Symbol include:
+
+- CachingOfAnyXFeed [eg. if X feeds fail, do something...where X is a number >= 1, if you set all the Feed handling to anything less than e-mail, this point can raise/e-mail once and only once]
+- Feed Aggregation Problem
+- Validity Check*
+- Other
+
+The ValidityCheck can be skipped during a cache, by passing setting the checkvalidity=False.  Big speed boost.
+
+Upon an exception getting caught, the handle object has the choice to 
+
+- [ ] enabled -> True/False Default, TRUE # this one silences all the rest, and will even ignore for reporting purposes
+- [ ] raise -> True/False Default, FALSE
+- [ ] warn -> True/False Default, FALSE
+- [ ] e-mail -> True/False Default, FALSE
+- [ ] dblog -> True/False Default, FALSE
+- [ ] txtlog -> True/False Default, TRUE
+- [ ] print -> True/False Default, TRUE
+- [ ] report -> True/False Default, TRUE
+
+Setting all to false, is therefore setting ignore to 

--- a/docs/source/framework.rst
+++ b/docs/source/framework.rst
@@ -20,6 +20,8 @@ Below is for illustrative purposes of the short-term plan for Trump.
          self.fnum = int
          self.state = str # ON/OFF 
          self.ftype = str # Feed type
+
+         self.handle = [int, int, int, ...]  #where each int, is actually a BitFlag representing what to do upon certain exceptions.
          
          self.tags = [str,]
          
@@ -31,7 +33,7 @@ Below is for illustrative purposes of the short-term plan for Trump.
          # feed. Eg. 'stype'.
          self.meta = {str : str,...}                       # { attr : value,}
          
-         #self.validity = {(str, str, str) : str,...}      # { (checkpoint, logic, key) : value,}    
+         #self.validity = ['function_name',int, str],]      # Simplified, for now...   
          self.munging = {(int, str) : {str : str,...},...} # { (order, mtype, method) : {argument : value,},}
         
    class Symbol(object):
@@ -40,6 +42,8 @@ Below is for illustrative purposes of the short-term plan for Trump.
          self.description = str
          self.freq = str         
          self.units = str
+
+         self.handle = [int, int, int, int]  #where each int, is actually a BitFlag representing what to do upon common exceptions.
          
          self.agg_method = str                      # PRIORITY, etc.
                                                     
@@ -48,7 +52,6 @@ Below is for illustrative purposes of the short-term plan for Trump.
                                                     
          self.feeds = [(int, Feed),...]             # [ (fnum, Feed),]
                                                     
-         self.validity = {(str, str, str) : str,...}# { (checkpoint, logic, key) : value,}
          
          self.datatable = Table(index,data,[Feed.data,Feed.data,...])
          

--- a/docs/source/objectmodel/orm.rst
+++ b/docs/source/objectmodel/orm.rst
@@ -12,6 +12,8 @@ Symbols
 
 .. autoclass:: trump.orm.SymbolTag
 
+.. autoclass:: trump.orm.SymbolHandle
+
 Feeds
 -----
 
@@ -22,6 +24,8 @@ Feeds
 .. autoclass:: trump.orm.FeedMunge
 
 .. autoclass:: trump.orm.FeedMungeArg
+
+.. autoclass:: trump.orm.FeedHandle
 
 Centralized Data Editing
 ------------------------

--- a/trump/orm.py
+++ b/trump/orm.py
@@ -49,7 +49,7 @@ from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.sql import and_
 from sqlalchemy import create_engine
 
-from trump.tools import ReprMixin, ProxyDict, isinstanceofany
+from trump.tools import ReprMixin, ProxyDict, BitFlag, isinstanceofany
 from trump.extensions.symbol_aggs import apply_row, choose_col
 from trump.templating import bFeed, pab, pnab
 from trump.options import read_config, read_settings
@@ -564,10 +564,10 @@ class SymbolValidity(Base, ReprMixin):
 class SymbolHandle(Base, ReprMixin):
     __tablename__ = "_symbol_handle"
 
-    caching_of_feeds = Column('caching_of_feeds', Integer)
-    feed_aggregation_problem = Column('feed_aggregation_problem', Integer)
-    validity_check = Column('validity_check', Integer)
-    other = Column('other', Integer)
+    caching_of_feeds = Column('caching_of_feeds', BitFlag)
+    feed_aggregation_problem = Column('feed_aggregation_problem', BitFlag)
+    validity_check = Column('validity_check', BitFlag)
+    other = Column('other', BitFlag)
 
     symbol = relationship("Symbol")
 
@@ -954,13 +954,13 @@ class FeedHandle(Base, ReprMixin):
     symname = Column('symname', String, primary_key=True)
     fnum = Column('fnum', Integer, primary_key=True)
 
-    api_failure = Column('api_failure', Integer)
-    empty_feed = Column('empty_feed', Integer)
-    index_type_problem = Column('index_type_problem', Integer)
-    index_property_problem = Column('index_property_problem', Integer)
-    data_type_problem = Column('data_type_problem', Integer)
-    non_monotonic = Column('non_monotonic', Integer)
-    other = Column('other', Integer)
+    api_failure = Column('api_failure', BitFlag)
+    empty_feed = Column('empty_feed', BitFlag)
+    index_type_problem = Column('index_type_problem', BitFlag)
+    index_property_problem = Column('index_property_problem', BitFlag)
+    data_type_problem = Column('data_type_problem', BitFlag)
+    non_monotonic = Column('non_monotonic', BitFlag)
+    other = Column('other', BitFlag)
 
     feed = relationship("Feed")
 

--- a/trump/orm.py
+++ b/trump/orm.py
@@ -55,6 +55,7 @@ from trump.extensions.symbol_aggs import apply_row, choose_col
 from trump.templating import bFeed, pab, pnab
 from trump.options import read_config, read_settings
 
+BitFlag.associate_with(BitFlagType)
 
 ENGINE_STR = read_config('readwrite')['engine']
 engine = create_engine(ENGINE_STR, echo=False)
@@ -1038,8 +1039,8 @@ if __name__ == '__main__':
     #oil.handle.egint = 10
     #print sm.ses.dirty
 
-    print oil.handle.caching_of_feeds
-    print oil.handle
+    #print oil.handle.caching_of_feeds
+    #print oil.handle
 
     #oil.handle.egint = 55
     #modify
@@ -1049,13 +1050,14 @@ if __name__ == '__main__':
     print oil.handle.caching_of_feeds.val
     print oil.handle
 
-    print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
-    oil.handle.caching_of_feeds['email'] = True
-    print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
-    oil.handle.caching_of_feeds = copy(oil.handle.caching_of_feeds)
-    print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+    #print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+    oil.handle.caching_of_feeds['txtlog'] = True
+    oil.handle.caching_of_feeds['txtlog'] = False
+    #print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+    #oil.handle.caching_of_feeds = copy(oil.handle.caching_of_feeds)
+    #print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
 
-    oil.handle.egint = 56
+    #oil.handle.egint = 56
 
     print oil.handle.caching_of_feeds
     print oil.handle.caching_of_feeds.val

--- a/trump/orm.py
+++ b/trump/orm.py
@@ -574,6 +574,7 @@ class SymbolHandle(Base, ReprMixin):
     symname = Column('symname', String, ForeignKey("_symbols.name", **CC),
                      primary_key=True)
 
+    egint = Column('egint', Integer)
     caching_of_feeds = Column('caching_of_feeds', BitFlagType)
     feed_aggregation_problem = Column('feed_aggregation_problem', BitFlagType)
     validity_check = Column('validity_check', BitFlagType)
@@ -581,7 +582,8 @@ class SymbolHandle(Base, ReprMixin):
 
     def __init__(self,symbol):
         self.symname = symbol.name
-        self.caching_of_feeds = BitFlag(2)
+        self.egint = 5
+        self.caching_of_feeds = BitFlag(3)
         self.feed_aggregation_problem = BitFlag(3)
         self.validity_check = BitFlag(10)
         self.other = BitFlag(0)
@@ -1023,13 +1025,48 @@ except ProgrammingError as pgerr:
 if __name__ == '__main__':
     sm = SymbolManager()
 
+    print "Getting Oil"
+
     oil = sm.create('oil')
 
-    print oil.handle.caching_of_feeds
-    oil.handle.caching_of_feeds['dblog'] = True
+    print oil
+
+    from copy import copy
+
+    print "The session should be clean:"
+    print sm.ses.dirty
+    #oil.handle.egint = 10
+    #print sm.ses.dirty
+
     print oil.handle.caching_of_feeds
     print oil.handle
 
+    #oil.handle.egint = 55
+    #modify
+    #oil.handle.caching_of_feeds = BitFlag(34)
+
+    print oil.handle.caching_of_feeds
+    print oil.handle.caching_of_feeds.val
+    print oil.handle
+
+    print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+    oil.handle.caching_of_feeds['email'] = True
+    print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+    oil.handle.caching_of_feeds = copy(oil.handle.caching_of_feeds)
+    print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+
+    oil.handle.egint = 56
+
+    print oil.handle.caching_of_feeds
+    print oil.handle.caching_of_feeds.val
+    print oil.handle
+
+    #print oil.handle.caching_of_feeds
+    print sm.ses.dirty
+
+    #print oil.handle
+
     sm.complete()
 
+    print sm.ses.dirty
     sm.finish()

--- a/trump/tests/notes/bitflagstesting.py
+++ b/trump/tests/notes/bitflagstesting.py
@@ -1,0 +1,40 @@
+
+n = BitFlag(8)
+print repr(n)
+print n.bools
+print n.bin
+print n.bin_str
+newd = n.asdict()
+print newd
+print n.val
+n = BitFlag(newd)
+print repr(n)
+print n.bools
+print n.bin
+print n.bin_str
+print n.asdict()
+n['raise'] = True
+n['raise'] = True
+n['email'] = True
+n['enabled'] = True
+print n.asdict()
+print n.val
+print repr(n)
+print BitFlag(n.val).asdict()
+print BitFlag(n.val).val
+print BitFlag(BitFlag(n.val).asdict()).val
+print repr(BitFlag(BitFlag(n.val).asdict()))
+
+one = BitFlag(1)
+print repr(one)
+print one
+print one()
+two = BitFlag(2)
+print repr(two)
+print two
+print two()
+print one | two
+
+print one() | two()
+
+print one()

--- a/trump/tests/notes/ormtesting.py
+++ b/trump/tests/notes/ormtesting.py
@@ -34,3 +34,59 @@
      SESSION.commit()
  SESSION.commit()
  mysymbol = SESSION.query(Symbol).all()[-1]
+
+
+
+
+
+
+###########################3333
+
+    sm = SymbolManager()
+
+    print "Getting Oil"
+
+    oil = sm.create('oil')
+
+    print oil
+
+    from copy import copy
+
+    print "The session should be clean:"
+    print sm.ses.dirty
+    #oil.handle.egint = 10
+    #print sm.ses.dirty
+
+    #print oil.handle.caching_of_feeds
+    #print oil.handle
+
+    #oil.handle.egint = 55
+    #modify
+    #oil.handle.caching_of_feeds = BitFlag(34)
+
+    print oil.handle.caching_of_feeds
+    print oil.handle.caching_of_feeds.val
+    print oil.handle
+
+    #print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+    oil.handle.caching_of_feeds['txtlog'] = True
+    oil.handle.caching_of_feeds['txtlog'] = False
+    #print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+    #oil.handle.caching_of_feeds = copy(oil.handle.caching_of_feeds)
+    #print "The id of caching_of_feeds is {}".format(id(oil.handle.caching_of_feeds))
+
+    #oil.handle.egint = 56
+
+    print oil.handle.caching_of_feeds
+    print oil.handle.caching_of_feeds.val
+    print oil.handle
+
+    #print oil.handle.caching_of_feeds
+    print sm.ses.dirty
+
+    #print oil.handle
+
+    sm.complete()
+
+    print sm.ses.dirty
+    sm.finish()

--- a/trump/tools/__init__.py
+++ b/trump/tools/__init__.py
@@ -1,1 +1,2 @@
 from trump.tools.sqla import *
+from trump.tools.bitflags import BitFlag

--- a/trump/tools/__init__.py
+++ b/trump/tools/__init__.py
@@ -1,2 +1,2 @@
 from trump.tools.sqla import *
-from trump.tools.bitflags import BitFlag
+from trump.tools.bitflags import BitFlag, BitFlagType

--- a/trump/tools/bitflags.py
+++ b/trump/tools/bitflags.py
@@ -1,6 +1,7 @@
 """
-Creates the BitFlag object, which enables efficient storage of the boolean
-array for each Handle catch point.
+Creates the BitFlag and BitFlagType object,
+which enables efficient storage of the boolean
+array for each Handle catch points.
 """
 from collections import OrderedDict as ODict
 from sqlalchemy.types import TypeDecorator, Integer
@@ -10,11 +11,11 @@ from sqlalchemy.ext.mutable import Mutable
 
 class BitFlag(Mutable, object):
     """
-    An object to semi-efficiently encode and decode a boolean array
-    into and from an an integer representing bitwise logic based flags
+    Semi-efficiently encode and decode a boolean array
+    as an an integer representing bitwise logic based flags
     """
-    flags = ['enabled', 'raise', 'warn', 'email',
-             'dblog', 'txtlog', 'stdout', 'report']
+    flags = ['raise', 'warn', 'email', 'dblog',
+             'txtlog', 'stdout', 'report']
 
     def __init__(self, obj, defaultflags=None):
         """
@@ -54,8 +55,9 @@ class BitFlag(Mutable, object):
 
         # a dict of the form {flags : bool, } was passed...
         # convert it to the boolean array just the same.
-        elif isinstance(obj, dict):
-
+        elif isinstance(obj, (dict,list)):
+            if isinstance(obj, list):
+                obj = dict(zip(obj,[True] * len(obj)))
             # if there are defaultflags, use them, otherwise assume all flages
             # are unset
             if defaultflags:
@@ -163,3 +165,5 @@ if __name__ == '__main__':
         print bf.asdict()
         print bf.bools
         print bf.bin
+
+    bf = BitFlag(['enabled','stdout','report'])

--- a/trump/tools/bitflags.py
+++ b/trump/tools/bitflags.py
@@ -3,15 +3,17 @@ Creates the BitFlag object, which enables efficient storage of the boolean
 array for each Handle catch point.
 """
 from collections import OrderedDict as ODict
+import sqlalchemy.types as sqlatypes
 
-
-class BitFlag(object):
+class BitFlag(sqlatypes.TypeDecorator):
     """
     An object to semi-efficiently encode and decode a boolean array
     into and from an an integer representing bitwise logic based flags
     """
     flags = ['enabled', 'raise', 'warn', 'email',
              'dblog', 'txtlog', 'stdout', 'report']
+
+    impl = sqlatypes.Integer
 
     def __init__(self, obj, defaultflags=None):
         """
@@ -120,3 +122,12 @@ class BitFlag(object):
             return BitFlag(other() | self())
         elif isinstance(other, int):
             return BitFlag(other | self())
+
+    def process_bind_param(self, value, dialect):
+        return value.val # or should this be self.val?
+
+    def process_result_value(self, value, dialect):
+        return BitFlag(value)
+
+    def copy(self):
+        return BitFlag(self.val)

--- a/trump/tools/bitflags.py
+++ b/trump/tools/bitflags.py
@@ -1,0 +1,122 @@
+"""
+Creates the BitFlag object, which enables efficient storage of the boolean
+array for each Handle catch point.
+"""
+from collections import OrderedDict as ODict
+
+
+class BitFlag(object):
+    """
+    An object to semi-efficiently encode and decode a boolean array
+    into and from an an integer representing bitwise logic based flags
+    """
+    flags = ['enabled', 'raise', 'warn', 'email',
+             'dblog', 'txtlog', 'stdout', 'report']
+
+    def __init__(self, obj, defaultflags=None):
+        """
+        :param obj, (int, dict):
+            either the decimal form of the bitwise array, or
+            a dictionary (complete or otherwise) of the form
+            {flag : bool, flag : bool, ...}
+        :param defaultflags, dict:
+            a dictionary representing the default for
+            one or more flags.  Only applicable
+            when a dictionary is passed to obj.  It's
+            ignored when obj is an integer.
+        :return:
+            BitFlag
+        """
+
+        # calculate an msb-like number, which is actually
+        # the msb * 2 to get one more digit than
+        # the number of flags
+
+        self.msb = 2 ** len(BitFlag.flags)
+
+        # if an integer was passed...
+        # convert it to a boolean array
+        if isinstance(obj, int):
+            self.val = obj % (self.msb >> 1)
+            self.val += self.msb
+
+            self.bools = []
+            while self.val != 0:
+                self.bools.append(self.val % 2 == 1)
+                self.val >>= 1
+            self.bools = self.bools[:-1]
+
+            for i, key in enumerate(BitFlag.flags):
+                setattr(self, key, self.bools[i])
+
+        # a dict of the form {flags : bool, } was passed...
+        # convert it to the boolean array just the same.
+        elif isinstance(obj, dict):
+
+            # if there are defaultflags, use them, otherwise assume all flages
+            # are unset
+            if defaultflags:
+                defaults = defaultflags
+            else:
+                defaults = zip(BitFlag.flags, [False] * len(BitFlag.flags))
+                defaults = ODict(defaults)
+
+            self.bools = []
+            self.val = 0
+            for i, key in enumerate(BitFlag.flags):
+                if key in obj:
+                    val = obj[key]
+                else:
+                    val = defaults[key]
+                setattr(self, key, val)
+                self.bools.append(val)
+                if val:
+                    self.val += 2 ** i
+
+    @property
+    def bin(self):
+        """ the binary equivalent """
+        return bin(self.val)
+
+    @property
+    def bin_str(self):
+        """ the binary equivalent, as a string """
+        return str(bin(self.val + self.msb))[3:]
+
+    def asdict(self):
+        """ convert the flags to a dictionary, with keys as flags. """
+        return {bit: self[bit] for bit in BitFlag.flags}
+
+    def __str__(self):
+        tmp = [b.upper() if self[b] else b for b in BitFlag.flags]
+        return " ".join(tmp)
+
+    def __repr__(self):
+        return "BitFlag({})".format(self.val)
+
+    def __getitem__(self, key):
+        return self.__getattribute__(key)
+
+    def __setitem__(self, key, value):
+        setattr(self, key, value)
+        self.bools[BitFlag.flags.index(key)] = value
+        # recalculate the value from scratch...
+        self.val = 0
+        for i, val in enumerate(self.bools):
+            if val:
+                self.val += 2 ** i
+
+    def __call__(self):
+        return self.val
+
+    def __and__(self, other):
+        if isinstance(other, BitFlag):
+            return BitFlag(other() & self())
+        elif isinstance(other, int):
+            return BitFlag(other & self())
+
+    def __or__(self, other):
+        if isinstance(other, BitFlag):
+            return BitFlag(other() | self())
+        elif isinstance(other, int):
+            return BitFlag(other | self())

--- a/trump/tools/bitflags.py
+++ b/trump/tools/bitflags.py
@@ -3,9 +3,10 @@ Creates the BitFlag object, which enables efficient storage of the boolean
 array for each Handle catch point.
 """
 from collections import OrderedDict as ODict
-import sqlalchemy.types as sqlatypes
+from sqlalchemy.types import TypeDecorator, Integer
 
-class BitFlag(sqlatypes.TypeDecorator):
+
+class BitFlag(TypeDecorator):
     """
     An object to semi-efficiently encode and decode a boolean array
     into and from an an integer representing bitwise logic based flags
@@ -13,7 +14,7 @@ class BitFlag(sqlatypes.TypeDecorator):
     flags = ['enabled', 'raise', 'warn', 'email',
              'dblog', 'txtlog', 'stdout', 'report']
 
-    impl = sqlatypes.Integer
+    impl = Integer
 
     def __init__(self, obj, defaultflags=None):
         """
@@ -123,6 +124,10 @@ class BitFlag(sqlatypes.TypeDecorator):
         elif isinstance(other, int):
             return BitFlag(other | self())
 
+class BitFlagType(TypeDecorator):
+
+    impl = Integer
+
     def process_bind_param(self, value, dialect):
         return value.val # or should this be self.val?
 
@@ -130,4 +135,4 @@ class BitFlag(sqlatypes.TypeDecorator):
         return BitFlag(value)
 
     def copy(self):
-        return BitFlag(self.val)
+        return BitFlagType()


### PR DESCRIPTION
I have this pure-python object, called a `BitFlag`, created [on the master branch](https://github.com/Equitable/trump/blob/474334500afd9998dfbde8584c9bb715e8ab6019/trump/tools/bitflags.py) and I'm trying to turn that into a [custom SQL Alchemy Type](http://docs.sqlalchemy.org/en/latest/core/custom_types.html).  This pull request, modifies the `BitFlag` object, several times as I experimented.  My first attempt, I create a second object, called a [BitFlagType](https://github.com/Equitable/trump/blob/773cf4f064baa7d885a19baf15928a79af573268/trump/tools/bitflags.py#L127) to just use in the column definition, but I think that was very wrong.  I tried to merge the logic, into the constructor of the `BitFlag` object, using `self.impl = Integer()` and [giving the arguments a default value](https://github.com/Equitable/trump/blob/cccf7572e38e52c224d686b917381ca8462f799b/trump/tools/bitflags.py#L19), but that isn't behaving as I would expect either.  

 Eg. when I modify via assignment, `MyRowObj.abitflagcol = BitFlag(5)` or when I use the special keys of my `MyRowObj.abitflagcol['aflag'] = True` it doesn't commit to the database the same way `MyRowObj.intcol = 5` does.
